### PR TITLE
feat: Configure asb to connect directly to monerod

### DIFF
--- a/mainnet/.env
+++ b/mainnet/.env
@@ -1,9 +1,6 @@
 # Monero daemon RPC port
 MONEROD_PORT=18081
 
-# Monero wallet RPC port
-MONERO_WALLET_RPC_PORT=18083
-
 # Bitcoin Core RPC port
 BITCOIND_RPC_PORT=8332
 

--- a/mainnet/config_mainnet.toml
+++ b/mainnet/config_mainnet.toml
@@ -16,7 +16,7 @@ target_block = 1
 network = "Mainnet"
 
 [monero]
-wallet_rpc_url = "http://mainnet_monero-wallet-rpc:18083/json_rpc"
+daemon_url = "http://mainnet_monerod:18081"
 network = "Mainnet"
 
 [tor]

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -18,27 +18,6 @@ services:
       - '--non-interactive'
       - '--enable-dns-blocklist'
       - '--data-dir=/monerod-data/mainnet'
-  mainnet_monero-wallet-rpc:
-    container_name: mainnet_monero-wallet-rpc
-    image: ghcr.io/sethforprivacy/simple-monero-wallet-rpc:v0.18.4.0
-    restart: unless-stopped
-    user: root
-    depends_on:
-      - mainnet_monerod
-    volumes:
-      - 'mainnet_monero-wallet-rpc-data:/monero-wallet-rpc-data/'
-    expose:
-      - ${MONERO_WALLET_RPC_PORT:?}
-    entrypoint: ''
-    command:
-      - monero-wallet-rpc
-      - '--rpc-bind-ip=0.0.0.0'
-      - '--rpc-bind-port=${MONERO_WALLET_RPC_PORT:?}'
-      - '--confirm-external-bind'
-      - '--daemon-address=mainnet_monerod:${MONEROD_PORT:?}'
-      - '--wallet-dir=/monero-wallet-rpc-data/'
-      - '--disable-rpc-login'
-      - '--trusted-daemon'
   mainnet_bitcoind:
     container_name: mainnet_bitcoind
     image: getumbrel/bitcoind:v28.0
@@ -84,7 +63,7 @@ services:
       - '--electrum-rpc-addr=0.0.0.0:${ELECTRS_PORT:?}'
       - '--log-filters=INFO'
   mainnet_asb:
-    image: ghcr.io/unstoppableswap/asb:latest
+    image: ghcr.io/unstoppableswap/asb:monero-sys-preview
     restart: unless-stopped
     container_name: mainnet_asb
     depends_on:
@@ -103,7 +82,7 @@ services:
       - 'start'
 volumes:
   mainnet_monerod-data:
-  mainnet_monero-wallet-rpc-data:
+  mainnet_monero-wallet-rpc-data: # Keeping this here for now to avoid the volume being pruned by docker
   mainnet_bitcoind-data:
   mainnet_electrs-data:
   mainnet_asb-data:

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -67,7 +67,6 @@ services:
     restart: unless-stopped
     container_name: mainnet_asb
     depends_on:
-      - mainnet_monero-wallet-rpc
       - mainnet_electrs
     volumes:
       - './config_mainnet.toml:/asb-data/config_mainnet.toml'

--- a/testnet/.env
+++ b/testnet/.env
@@ -1,9 +1,6 @@
 # Monero stagenet daemon RPC port
 MONEROD_PORT=38081
 
-# Monero stagenet wallet RPC port
-MONERO_WALLET_RPC_PORT=38083
-
 # Bitcoin testnet Core RPC port
 BITCOIND_RPC_PORT=18332
 

--- a/testnet/config_testnet.toml
+++ b/testnet/config_testnet.toml
@@ -16,7 +16,7 @@ target_block = 1
 network = "Testnet"
 
 [monero]
-daemon_url = "http://stagenet_monero-wallet-rpc:38081"
+daemon_url = "http://stagenet_monerod:38081"
 network = "Stagenet"
 
 [tor]

--- a/testnet/config_testnet.toml
+++ b/testnet/config_testnet.toml
@@ -16,7 +16,7 @@ target_block = 1
 network = "Testnet"
 
 [monero]
-wallet_rpc_url = "http://stagenet_monero-wallet-rpc:38083/json_rpc"
+daemon_url = "http://stagenet_monero-wallet-rpc:38081"
 network = "Stagenet"
 
 [tor]

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -19,28 +19,6 @@ services:
       - '--enable-dns-blocklist'
       - '--data-dir=/monerod-data/stagenet'
       - '--stagenet'  # Added for stagenet
-  stagenet_monero-wallet-rpc:
-    container_name: stagenet_monero-wallet-rpc
-    image: ghcr.io/sethforprivacy/simple-monero-wallet-rpc:v0.18.4.0
-    restart: unless-stopped
-    user: root
-    depends_on:
-      - stagenet_monerod
-    volumes:
-      - 'stagenet_monero-wallet-rpc-data:/monero-wallet-rpc-data/'
-    expose:
-      - ${MONERO_WALLET_RPC_PORT:?}
-    entrypoint: ''
-    command:
-      - monero-wallet-rpc
-      - '--rpc-bind-ip=0.0.0.0'
-      - '--rpc-bind-port=${MONERO_WALLET_RPC_PORT:?}'
-      - '--confirm-external-bind'
-      - '--daemon-address=stagenet_monerod:${MONEROD_PORT:?}'
-      - '--wallet-dir=/monero-wallet-rpc-data/'
-      - '--disable-rpc-login'
-      - '--trusted-daemon'
-      - '--stagenet'  # Added for stagenet
   testnet_bitcoind:
     container_name: testnet_bitcoind
     image: getumbrel/bitcoind:v28.0
@@ -86,7 +64,7 @@ services:
       - '--electrum-rpc-addr=0.0.0.0:${ELECTRS_PORT:?}'
       - '--log-filters=INFO'
   testnet_asb:
-    image: ghcr.io/unstoppableswap/asb:latest
+    image: ghcr.io/unstoppableswap/asb:monero-sys-preview
     restart: unless-stopped
     container_name: testnet_asb
     depends_on:
@@ -106,7 +84,7 @@ services:
       - 'start'
 volumes:
   stagenet_monerod-data:
-  stagenet_monero-wallet-rpc-data:
+  stagenet_monero-wallet-rpc-data: # Keeping this here for now to avoid the volume being pruned by docker
   testnet_bitcoind-data:
   testnet_electrs-data:
   testnet_asb-data:

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -68,7 +68,6 @@ services:
     restart: unless-stopped
     container_name: testnet_asb
     depends_on:
-      - stagenet_monero-wallet-rpc
       - testnet_electrs
     volumes:
       - './config_testnet.toml:/asb-data/config_testnet.toml'


### PR DESCRIPTION
This makes the necessary changed to prepare for this upgrade: https://github.com/UnstoppableSwap/core/pull/303

The `asb` now directly connects to `monerod`. The `monero-wallet-rpc` container has been removed as it is not needed anymore. The config files have been updated to specify the `monerod` connection url.